### PR TITLE
(LiDAR-145) Front Door Integration

### DIFF
--- a/lib/puppet/reports/lidar.rb
+++ b/lib/puppet/reports/lidar.rb
@@ -18,31 +18,12 @@ Puppet::Reports.register_report(:lidar) do
 
     Puppet.info "LiDAR sending report to #{lidar_url}"
 
-    url = URI.parse(lidar_url)
-    headers = { "Content-Type" => "application/json" }
-    # This metric_id option is silently ignored by Puppet's http client
-    # (Puppet::Network::HTTP) but is used by Puppet Server's http client
-    # (Puppet::Server::HttpClient) to track metrics on the request made to the
-    # `reporturl` to store a report.
-    options = { :metric_id => [:puppet, :report, :lidar] }
-    if url.user && url.password
-      options[:basic_auth] = {
-        :user => url.user,
-        :password => url.password
-      }
-    end
-    use_ssl = url.scheme == 'https'
-    ssl_context = use_ssl ? Puppet.lookup(:ssl_context) : nil
-    conn = Puppet::Network::HttpPool.connection(url.host, url.port, use_ssl: use_ssl, ssl_context: ssl_context)
-
     # Add in pe_console & producer fields
     report_payload = JSON.parse(self.to_json)
     report_payload['pe_console'] = pe_console
     report_payload['producer'] = Puppet[:certname]
 
-    response = conn.post(url.path, report_payload.to_json, headers, options)
-    unless response.kind_of?(Net::HTTPSuccess)
-      Puppet.err _("LiDAR unable to submit report to %{url} [%{code}] %{message}") % { url: url.path, code: response.code, message: response.msg }
-    end
+    send_to_lidar(lidar_url, report_payload)
+
   end
 end


### PR DESCRIPTION
Updated module to use Net::HTTP so that we can easily use OpenSSL::SSL::VERIFY_NONE and have greater control over the timeouts.

Code currently applied on https://puritan-roundup.delivery.puppetlabs.net:8443/dashboard

Have not run rubocop as linting errors have been fixed in @genebean PR.