### PR TITLE
Made fact useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ See [REFERENCE.md](REFERENCE.md) for example usage.
 
 ## Reference
 
+A custom fact named `lidar` is included as part of this module. It is a structured fact that returns information about the currently running instance of LiDAR.
+
 This module is documented via `pdk bundle exec puppet strings generate --format markdown`. Please see [REFERENCE.md](REFERENCE.md) for more info.
 
 ## Changelog


### PR DESCRIPTION
Updated fact to provide useful info about the services defined in the docker-compose file. The sample below was created in Vagrant where everything was done via `puppet apply`, thus the need to specify a modulepath.

```
[root@localhost ~]# puppet facts --modulepath /etc/puppetlabs/code/environments/production/modules |jq '.values.lidar'
{
  "lidar_influxdb_1": {
    "repository": "influxdb",
    "tag": "1.7",
    "image_id": "a49f4accc06b"
  },
  "lidar_ingest-queue_1": {
    "repository": "artifactory.delivery.pup",
    "tag": "latest",
    "image_id": "a1c0d99d00e2"
  },
  "lidar_mongo_1": {
    "repository": "artifactory.delivery.puppetla",
    "tag": "latest",
    "image_id": "df6605aef11e"
  },
  "lidar_mongo-express_1": {
    "repository": "mongo-express",
    "tag": "latest",
    "image_id": "ff3cf5acef2a"
  },
  "lidar_query_1": {
    "repository": "artifactory.delivery.puppetla",
    "tag": "latest",
    "image_id": "98fa3dadf4fd"
  },
  "lidar_rabbitmq_1": {
    "repository": "rabbitmq",
    "tag": "3.8-management",
    "image_id": "44c4867e4a8b"
  },
  "lidar_ui_1": {
    "repository": "artifactory.delivery.puppetlabs.",
    "tag": "latest",
    "image_id": "6cda32f5515d"
  }
}
```