### PR TITLE
(LiDAR-145) update compose template 

### DIFF
--- a/templates/docker-compose.yaml.epp
+++ b/templates/docker-compose.yaml.epp
@@ -7,8 +7,8 @@ services:
     image: "artifactory.delivery.puppetlabs.net/lidar/frontdoor:<%= $lidar_version %>"
     restart: always
     environment:
-      - IDENTITY_SERVER=https://<%= $facts[networking][fqdn] %>:8443/auth/
-      - TOOL_DOMAIN=https://<%= $facts[networking][fqdn] %>:8443/
+      - IDENTITY_SERVER=https://<%= $facts["networking"]["fqdn"] %>:8443/auth/
+      - TOOL_DOMAIN=https://<%= $facts["networking"]["fqdn"] %>:8443/
     links:
       - identity
     ports:
@@ -64,8 +64,8 @@ services:
   ui:
     image: "artifactory.delivery.puppetlabs.net/lidar/ui:<%= $lidar_version %>"
     environment:
-      - REACT_APP_QUERY_API=https://<%= $facts[networking][fqdn] %>:8443/query
-      - REACT_APP_IDENTITY=https://<%= $facts[networking][fqdn] %>:8443/auth
+      - REACT_APP_QUERY_API=https://<%= $facts["networking"]["fqdn"] %>:8443/query
+      - REACT_APP_IDENTITY=https://<%= $facts["networking"]["fqdn"] %>:8443/auth
 
   query:
     tty: true


### PR DESCRIPTION
Updates to the docker-compose template required as part of https://github.com/puppetlabs/lidar/pull/88 

When the above is merged, this will need to be as well.

A Make Command has been created as follows to create this template;
`create-docker-compose-epp:
    cp deploy-docker-compose.yml docker-compose.yaml.epp
    sed -i '' 's/$${DOMAIN:?Need to set DOMAIN in a .env file}/<%= $$facts["networking"]["fqdn"] %>/' docker-compose.yaml.epp
    sed -i '' 's/$${IDENTITY:?Need to set IDENTITY in a .env file}/<%= $$facts["networking"]["fqdn"] %>/' docker-compose.yaml.epp
    sed -i '' 's/$${LIDAR_TAG:-latest}/<%= $$lidar_version %>/' docker-compose.yaml.epp
    cat docker-compose.yaml.epp`