### PR TITLE
(maint) add option to disable docker install

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -59,13 +59,13 @@ Ensure the docker group is present.
 
 Default value: `true`
 
-##### `http_port`
+##### `manage_docker`
 
-Data type: `Integer`
+Data type: `Boolean`
 
-Insecure port number to access the LiDAR UI
+Install and manage docker as part of app_stack
 
-Default value: 80
+Default value: `true`
 
 ##### `https_port`
 

--- a/templates/docker-compose.yaml.epp
+++ b/templates/docker-compose.yaml.epp
@@ -1,5 +1,4 @@
 <%- | Boolean $analytics,
-      Integer $http_port,
       Integer $https_port,
       String[1] $lidar_version,
 | -%>
@@ -17,7 +16,6 @@ services:
       - identity
     ports:
       - <%= $https_port %>:443
-      - <%= $http_port %>:80
 
   identity:
     image: "artifactory.delivery.puppetlabs.net/lidar/identity:<%= $lidar_version %>"


### PR DESCRIPTION
Added option to not install docker/compose as part of lidar::app_stack
This will give users greater control of how they want to install docker. For example, if in an air gapped env

Also removed the http option. http port 80 is no longer exposed in the dockerfile.

Currently code running here: https://brutal-justice.delivery.puppetlabs.net:8843/
