### PR TITLE
(maint) keep data-util open

### DIFF
--- a/templates/docker-compose.yaml.epp
+++ b/templates/docker-compose.yaml.epp
@@ -8,6 +8,7 @@ version: '3'
 services:
   data-util:
     image: "<%= $image_prefix %>data-util:<%= $lidar_version %>"
+    tty: true
     environment:
       - DATA_DIR=/data
     volumes:


### PR DESCRIPTION
Quick update to keep the data-util container running.

Otherwise on every puppet run, docker-compose up results in the data-util container starting up and exiting. This results in a changed report every run due to corrective change. This change should be included in the release so the tag will need to be moved to this commit when merged.

The change also should be put into the deploy-docker compose file within the lidar repo.