### PR TITLE
(INFC-19232) Allow for sending data to multiple LiDAR servers

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -8,6 +8,10 @@
 * [`lidar::app_stack`](#lidarapp_stack): Configure a node to run LiDAR
 * [`lidar::report_processor`](#lidarreport_processor): Simple class to enable the LiDAR report processor
 
+**Data types**
+
+* [`Lidar::Url`](#lidarurl): 
+
 **Tasks**
 
 * [`get_service_status`](#get_service_status): Get the status of the LiDAR docker-compose services
@@ -164,13 +168,23 @@ class { 'profile::masters_and_compilers':
 }
 ```
 
+##### Send data to two LiDAR servers
+
+```puppet
+---
+lidar::report_processor::lidar_url:
+  - 'https://lidar-prod.example.com:8443/in'
+  - 'https://lidar-staging.example.com:8443/in'
+lidar::report_processor::pe_console: 'pe-console.example.com'
+```
+
 #### Parameters
 
 The following parameters are available in the `lidar::report_processor` class.
 
 ##### `lidar_url`
 
-Data type: `Stdlib::HTTPUrl`
+Data type: `Lidar::Url`
 
 The url to send reports to.
 
@@ -221,6 +235,14 @@ Data type: `Optional[Stdlib::Fqdn]`
 The FQDN of your PE Console.
 
 Default value: `undef`
+
+## Data types
+
+### Lidar::Url
+
+The Lidar::Url data type.
+
+Alias of `Variant[Array[Stdlib::HTTPUrl], Stdlib::HTTPUrl]`
 
 ## Tasks
 

--- a/lib/puppet/reports/lidar.rb
+++ b/lib/puppet/reports/lidar.rb
@@ -13,15 +13,17 @@ Puppet::Reports.register_report(:lidar) do
   include Puppet::Util::Lidar
 
   def process
-    lidar_url = settings['lidar_url'] + '/data'
-
-    Puppet.info "LiDAR sending report to #{lidar_url}"
-
     # Add in pe_console & producer fields
     report_payload = JSON.parse(to_json)
     report_payload['pe_console'] = pe_console
     report_payload['producer'] = Puppet[:certname]
 
-    send_to_lidar(lidar_url, report_payload)
+    lidar_urls = settings['lidar_urls']
+
+    lidar_urls.each do |url|
+      lidar_url = "#{url}/data"
+      Puppet.info "LiDAR sending report to #{lidar_url}"
+      send_to_lidar(lidar_url, report_payload)
+    end
   end
 end

--- a/lib/puppet/util/lidar.rb
+++ b/lib/puppet/util/lidar.rb
@@ -9,7 +9,8 @@ require 'uri'
 require 'yaml'
 require 'json'
 require 'time'
-# splunk_hec.rb
+
+# Utility functions used by the report processor and the facts indirector.
 module Puppet::Util::Lidar
   def settings
     return @settings if @settings
@@ -53,8 +54,7 @@ module Puppet::Util::Lidar
   end
 
   def send_facts(request, time)
-    lidar_facts_url = settings['lidar_url'] + '/facts'
-    lidar_packages_url = settings['lidar_url'] + '/packages'
+    lidar_urls = settings['lidar_urls']
 
     # Copied from the puppetdb fact indirector.  Explicitly strips
     # out the packages custom fact '_puppet_inventory_1'
@@ -84,7 +84,11 @@ module Puppet::Util::Lidar
 
     # Puppet.info "***LiDAR facts #{request_body.to_json}"
 
-    send_to_lidar(lidar_facts_url, request_body)
+    lidar_urls.each do |url|
+      lidar_facts_url = "#{url}/facts"
+
+      send_to_lidar(lidar_facts_url, request_body)
+    end
 
     return unless package_inventory
     package_request = {
@@ -98,6 +102,9 @@ module Puppet::Util::Lidar
 
     # Puppet.info "***LiDAR packages #{package_request.to_json}"
 
-    send_to_lidar(lidar_packages_url, package_request)
+    lidar_urls.each do |url|
+      lidar_packages_url = "#{url}/packages"
+      send_to_lidar(lidar_packages_url, package_request)
+    end
   end
 end

--- a/manifests/report_processor.pp
+++ b/manifests/report_processor.pp
@@ -2,7 +2,7 @@
 #
 # @summary Simple class to enable the LiDAR report processor
 #
-# @param [Stdlib::HTTPUrl] lidar_url
+# @param [Lidar::Url] lidar_url
 #   The url to send reports to.
 #
 # @param [Boolean] enable_reports
@@ -48,8 +48,16 @@
 #       pe_console => 'pe-console.example.com',
 #     }
 #   }
+#
+# @example Send data to two LiDAR servers
+#   ---
+#   lidar::report_processor::lidar_url:
+#     - 'https://lidar-prod.example.com:8443/in'
+#     - 'https://lidar-staging.example.com:8443/in'
+#   lidar::report_processor::pe_console: 'pe-console.example.com'
+#
 class lidar::report_processor (
-  Stdlib::HTTPUrl $lidar_url,
+  Lidar::Url $lidar_url,
   Boolean $enable_reports = true,
   Boolean $manage_routes = true,
   String[1] $facts_terminus = 'puppetdb',
@@ -94,7 +102,10 @@ class lidar::report_processor (
     owner   => pe-puppet,
     group   => pe-puppet,
     mode    => '0640',
-    content => epp('lidar/lidar.yaml.epp'),
+    content => epp('lidar/lidar.yaml.epp', {
+      'lidar_urls' => Array($lidar_url, true),
+      'pe_console' => $pe_console,
+    }),
     notify  => Service['pe-puppetserver'],
   }
 }

--- a/spec/classes/report_processor_spec.rb
+++ b/spec/classes/report_processor_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'lidar::report_processor' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      let(:pre_condition) { "service { 'pe-puppetserver': }" }
+
+      # rubocop:disable Metrics/LineLength
+      context 'with a lidar_url string value' do
+        let(:params) do
+          {
+            'lidar_url' => 'https://lidar.example.com/in',
+            'pe_console' => 'pe-console.example.com',
+          }
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_file('/etc/puppetlabs/puppet/lidar.yaml').with_content(%r{^# managed by puppet lidar module\n---\n'lidar_urls':\n  - 'https://lidar.example.com/in'\n'pe_console': 'pe-console.example.com'\n$}) }
+      end
+
+      context 'with a lidar_url array value' do
+        let(:params) do
+          {
+            'lidar_url' => [
+              'https://lidar-prod.example.com/in',
+              'https://lidar-stage.example.com/in',
+            ],
+            'pe_console' => 'pe-console.example.com',
+          }
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to contain_file('/etc/puppetlabs/puppet/lidar.yaml').with_content(%r{^# managed by puppet lidar module\n---\n'lidar_urls':\n  - 'https://lidar-prod.example.com/in'\n  - 'https://lidar-stage.example.com/in'\n'pe_console': 'pe-console.example.com'\n$}) }
+      end
+      # rubocop:enable Metrics/LineLength
+    end
+  end
+end

--- a/templates/lidar.yaml.epp
+++ b/templates/lidar.yaml.epp
@@ -1,6 +1,12 @@
+<%- | Array[Stdlib::HTTPUrl] $lidar_urls,
+      Optional[Stdlib::Fqdn] $pe_console = undef,
+| -%>
 # managed by puppet lidar module
 ---
-'lidar_url': "<%= $lidar::report_processor::lidar_url %>"
-<% if $lidar::report_processor::pe_console{ -%>
-'pe_console': "<%= $lidar::report_processor::pe_console %>"
+'lidar_urls':
+<%  $lidar_urls.each |$url| { -%>
+  - '<%= $url %>'
+<% } -%>
+<% if $pe_console{ -%>
+'pe_console': '<%= $pe_console %>'
 <% } -%>

--- a/types/url.pp
+++ b/types/url.pp
@@ -1,0 +1,1 @@
+type Lidar::Url = Variant[Array[Stdlib::HTTPUrl], Stdlib::HTTPUrl]


### PR DESCRIPTION
This PR modifies the report processor and the config file template to support a single Puppet server sending data to multiple LiDAR servers.