### PR TITLE
Increase max values per tag limit

### DIFF
--- a/templates/docker-compose.yaml.epp
+++ b/templates/docker-compose.yaml.epp
@@ -55,6 +55,7 @@ services:
       - ./backup:/backup
     environment:
       - INFLUXDB_DB=reports
+      - INFLUXDB_DATA_MAX_VALUES_PER_TAG=400000
 
   ingest-queue:
     image: "<%= $image_prefix %>ingest-queue:<%= $lidar_version %>"


### PR DESCRIPTION
Are test system has stopped collecting report data after 9 or so days. We want to increase the number of series assigned to a tag so that the system will run for longer.  