### PR TITLE
Update to 1.0.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.0.0-alpha.2](https://github.com/puppetlabs/puppetlabs-lidar/tree/1.0.0-alpha.2) (2020-02-04)
+
+[Full Changelog](https://github.com/puppetlabs/puppetlabs-lidar/compare/1.0.0-alpha...1.0.0-alpha.2)
+
+### Added
+
+- \(INFC-19232\) Allow for sending data to multiple LiDAR servers [\#20](https://github.com/puppetlabs/puppetlabs-lidar/pull/20) ([genebean](https://github.com/genebean))
+
+### Fixed
+
+- Increase max values per tag limit [\#21](https://github.com/puppetlabs/puppetlabs-lidar/pull/21) ([Lukeaber](https://github.com/Lukeaber))
+
 ## [1.0.0-alpha](https://github.com/puppetlabs/puppetlabs-lidar/tree/1.0.0-alpha) (2019-12-19)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-lidar/compare/6ee29505bbb8682ed2cf5852be63c2ecef1a76ad...1.0.0-alpha)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -104,7 +104,7 @@ Data type: `String[1]`
 
 The version of the LiDAR containers to use
 
-Default value: '1.0.0-alpha'
+Default value: '1.0.0-alpha.2'
 
 ##### `log_driver`
 

--- a/manifests/app_stack.pp
+++ b/manifests/app_stack.pp
@@ -50,7 +50,7 @@ class lidar::app_stack (
   Integer $https_port = 443,
   String[1] $compose_version = '1.25.0',
   String[1] $image_prefix = 'puppet/lidar-',
-  String[1] $lidar_version = '1.0.0-alpha',
+  String[1] $lidar_version = '1.0.0-alpha.2',
   String[1] $log_driver = 'journald',
   Optional[Array[String[1]]] $docker_users = undef,
 ){

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-lidar",
-  "version": "1.0.0-alpha",
+  "version": "1.0.0-alpha.2",
   "author": "jpc",
   "summary": "Configures Puppet LiDAR",
   "license": "Apache-2.0",

--- a/spec/classes/app_stack_spec.rb
+++ b/spec/classes/app_stack_spec.rb
@@ -12,7 +12,7 @@ describe 'lidar::app_stack' do
         it { is_expected.to  contain_class('docker::compose').with_ensure('present') }
         it { is_expected.to  contain_file('/opt/puppetlabs/lidar').with_ensure('directory') }
         it { is_expected.to  contain_file('/opt/puppetlabs/lidar/backup').with_ensure('directory') }
-        it { is_expected.to  contain_file('/opt/puppetlabs/lidar/docker-compose.yaml').with_content(%r{puppet\/lidar-ingest-queue:\d+\.\d+\.\d+(-[a-z]+)?"$}) }
+        it { is_expected.to  contain_file('/opt/puppetlabs/lidar/docker-compose.yaml').with_content(%r{puppet\/lidar-ingest-queue:\d+\.\d+\.\d+(-[a-z]+(\.[0-9]+)?)?"$}) }
         it { is_expected.to  contain_docker_compose('lidar').with_compose_files(['/opt/puppetlabs/lidar/docker-compose.yaml']) }
       end
     end


### PR DESCRIPTION
This PR updates the default version to be installed to 1.0.0-alpha.2. It also updates a spec test to account for the ".2" added to the end of the version string. Lastly, it also updates the changelog
and reference docs.